### PR TITLE
feat: Exclude some high volume events

### DIFF
--- a/audit.rules
+++ b/audit.rules
@@ -513,7 +513,7 @@
 -a always,exit -F arch=b64 -S ptrace -F a0=0x4 -k code_injection
 -a always,exit -F arch=b64 -S ptrace -F a0=0x5 -k data_injection
 -a always,exit -F arch=b64 -S ptrace -F a0=0x6 -k register_injection
--a always,exit -F arch=b64 -S ptrace -k tracing
+#-a always,exit -F arch=b64 -S ptrace -k tracing
 
 ## Anonymous File Creation
 ### These rules watch the use of memfd_create

--- a/audit.rules
+++ b/audit.rules
@@ -103,6 +103,13 @@
 ## FileBeat
 -a never,exit -F arch=b64 -F path=/opt/filebeat -k filebeat
 
+## SNMP
+-a never,exit -F arch=b64 -S open -F dir=/usr/share/snmp/mibs -F exe=/usr/bin/snmpget -k snmp
+-a never,exit -F arch=b64 -S open -F dir=/usr/share/snmp/mibs -F exe=/usr/bin/snmpwalk -k snmp
+
+## Git
+-a never,exit -F arch=b64 -S unlink -F exe=/usr/bin/git -k git
+
 ## More information on how to filter events
 ### https://access.redhat.com/solutions/2482221
 


### PR DESCRIPTION
Add rules to exclude high volume events on some hosts:

## SNMP

Exclude errors while accessing `/usr/share/snmp/mibs/*` from `snmpget` and `snmpwalk`. 

The associated rules are:

```
### Unauthorized Access (unsuccessful)
-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=-1 -k file_access
-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=-1 -k file_access
```

## GIT

Exclude file deletion events caused by git. 

The associated matching rule is

```
## File Deletion Events by User
-a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=-1 -k delete
```

## ptrace

Do not create event for `ptrace` calls that are not directly linked to an injection

Removed rule:

```
-a always,exit -F arch=b64 -S ptrace -k tracing
```